### PR TITLE
Permission Management UI Updates - Read-only Mode

### DIFF
--- a/src/sections/role/permission.jsx
+++ b/src/sections/role/permission.jsx
@@ -5,9 +5,7 @@ import Box from '@mui/material/Box';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import Paper from '@mui/material/Paper';
-import Alert from '@mui/material/Alert';
 import Switch from '@mui/material/Switch';
-import Checkbox from '@mui/material/Checkbox';
 import Collapse from '@mui/material/Collapse';
 import LockIcon from '@mui/icons-material/Lock';
 import Typography from '@mui/material/Typography';
@@ -20,12 +18,8 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 const PermissionsManager = ({ resources, permissions }) => {
   const [activeTab, setActiveTab] = useState("api");
   const [expandedCards, setExpandedCards] = useState({});
-  const [selectAll, setSelectAll] = useState({
-    api: false,
-    client: false,
-  });
+
   const [resourceSelections, setResourceSelections] = useState({});
-  const [showUnsavedAlert, setShowUnsavedAlert] = useState(false);
 
   useEffect(() => {
     const selections = {};
@@ -62,24 +56,6 @@ const PermissionsManager = ({ resources, permissions }) => {
     }));
   };
 
-  const handleSelectAllAPI = (checked) => {
-    setSelectAll((prev) => ({ ...prev, api: checked }));
-    const newSelections = { ...resourceSelections };
-
-    resources
-      .filter((resource) => resource.type === 'api')
-      .forEach((resource) => {
-        if (checked) {
-          newSelections[resource._id].identifiers.add(resource.identifier);
-        } else {
-          newSelections[resource._id].identifiers.delete(resource.identifier);
-        }
-      });
-
-    setResourceSelections(newSelections);
-    setShowUnsavedAlert(true);
-  };
-
   const handleMethodToggle = (resourceId, identifier) => {
     const newSelections = { ...resourceSelections };
     if (newSelections[resourceId].identifiers.has(identifier)) {
@@ -88,25 +64,6 @@ const PermissionsManager = ({ resources, permissions }) => {
       newSelections[resourceId].identifiers.add(identifier);
     }
     setResourceSelections(newSelections);
-    setShowUnsavedAlert(true);
-  };
-
-  const handleSelectAllClient = (checked) => {
-    setSelectAll((prev) => ({ ...prev, client: checked }));
-    const newSelections = { ...resourceSelections };
-
-    resources
-      .filter((resource) => resource.type === 'client')
-      .forEach((resource) => {
-        if (checked) {
-          newSelections[resource._id].identifiers.add(resource.identifier);
-        } else {
-          newSelections[resource._id].identifiers.delete(resource.identifier);
-        }
-      });
-
-    setResourceSelections(newSelections);
-    setShowUnsavedAlert(true);
   };
 
   const groupResourcesByModule = (data) => data.reduce((acc, resource) => {
@@ -125,15 +82,6 @@ const PermissionsManager = ({ resources, permissions }) => {
   // Render API Permissions Section
   const renderAPIPermissions = () => (
     <Box sx={{ mt: 2 }}>
-      <FormControlLabel
-        control={
-          <Checkbox
-            checked={selectAll.api}
-            onChange={(e) => handleSelectAllAPI(e.target.checked)}
-          />
-        }
-        label="Select All API Permissions"
-      />
 
       {Object.keys(groupedResources).map((moduleName) => {
         const resourcesByModule = groupedResources[moduleName];
@@ -171,6 +119,7 @@ const PermissionsManager = ({ resources, permissions }) => {
                           key={resource.identifier}
                           control={
                             <Switch
+                              disabled
                               checked={isChecked}
                               onChange={() => handleMethodToggle(resource._id, resource.identifier)}
                             />
@@ -196,6 +145,7 @@ const PermissionsManager = ({ resources, permissions }) => {
                               key={resource.identifier}
                               control={
                                 <Switch
+                                  disabled
                                   checked={isChecked}
                                   onChange={() => handleMethodToggle(resource._id, resource.identifier)}
                                 />
@@ -218,16 +168,6 @@ const PermissionsManager = ({ resources, permissions }) => {
   // Render Client Permissions Section
   const renderClientPermissions = () => (
     <Box sx={{ mt: 2 }}>
-      <FormControlLabel
-        control={
-          <Checkbox
-            checked={selectAll.client}
-            onChange={(e) => handleSelectAllClient(e.target.checked)}
-          />
-        }
-        label="Select All UI Permissions"
-      />
-
       {Object.keys(groupedResources).map((moduleName) => {
         const resourcesByModule = groupedResources[moduleName];
         return (
@@ -262,6 +202,7 @@ const PermissionsManager = ({ resources, permissions }) => {
                       <FormControlLabel
                         control={
                           <Switch
+                            disabled
                             checked={isChecked}
                             onChange={() => handleMethodToggle(resource._id, resource.identifier)}
                           />
@@ -304,16 +245,6 @@ const PermissionsManager = ({ resources, permissions }) => {
           </Typography>
         </Box>
       </Box>
-
-      {showUnsavedAlert && (
-        <Alert
-          severity="warning"
-          sx={{ mb: 2 }}
-          onClose={() => setShowUnsavedAlert(false)}
-        >
-          You have unsaved changes. Don&apos;t forget to save before leaving!
-        </Alert>
-      )}
 
       <Paper sx={{ mb: 3 }}>
         <Tabs

--- a/src/sections/role/role-create-form.jsx
+++ b/src/sections/role/role-create-form.jsx
@@ -8,7 +8,6 @@ import Stack from '@mui/material/Stack';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import Typography from '@mui/material/Typography';
-import LoadingButton from '@mui/lab/LoadingButton';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
@@ -78,7 +77,7 @@ export default function RoleCreateForm({ open, onClose, role, resources }) {
     <Dialog open={open} onClose={() => onClose(false)} maxWidth="sm" fullWidth>
       <DialogTitle>
         <Typography variant="h3">
-          {role?._id ? 'Edit Role' : 'Create New Role'}
+          View Role
         </Typography>
       </DialogTitle>
 
@@ -107,16 +106,8 @@ export default function RoleCreateForm({ open, onClose, role, resources }) {
 
       <DialogActions>
         <Button onClick={() => onClose(false)} disabled={isSubmitting}>
-          Cancel
+          Close
         </Button>
-        <LoadingButton
-          variant="contained"
-          loading={isSubmitting}
-          onClick={onSubmit}
-          disabled={isSubmitting}
-        >
-          {role?._id ? 'Update' : 'Create'} Role
-        </LoadingButton>
       </DialogActions>
     </Dialog>
   );

--- a/src/sections/role/role-table-toolbar.jsx
+++ b/src/sections/role/role-table-toolbar.jsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import Stack from '@mui/material/Stack';
-import Button from '@mui/material/Button';
 import Toolbar from '@mui/material/Toolbar';
 import OutlinedInput from '@mui/material/OutlinedInput';
 import InputAdornment from '@mui/material/InputAdornment';
@@ -15,10 +14,6 @@ import RoleCreateForm from './role-create-form';
 
 export default function RoleTableToolbar({ filterName, onFilterName }) {
   const [open, setOpen] = useState(false);
-
-  const handleOpen = () => {
-    setOpen(true);
-  };
 
   const handleClose = () => {
     setOpen(false);
@@ -47,13 +42,6 @@ export default function RoleTableToolbar({ filterName, onFilterName }) {
             </InputAdornment>
           }
         />
-        <Button
-          variant="contained"
-          startIcon={<Iconify icon="eva:plus-fill" />}
-          onClick={() => handleOpen()}
-        >
-          Add New Role
-        </Button>
       </Toolbar>
 
       <RoleCreateForm

--- a/src/sections/user/view/user-dialog.jsx
+++ b/src/sections/user/view/user-dialog.jsx
@@ -91,6 +91,8 @@ export default function AlertDialog({ open, closeDialog, user }) {
   // Check if current user can manage user activation
   const canManageActivation = currentUser.isSuperAdmin || currentUser.isAdmin;
 
+  console.log('user dialog', { user, currentUser });
+
   return (
     <Dialog
       open={open}


### PR DESCRIPTION
## Changes Overview
This PR modifies the permissions management interface to implement a read-only mode, removing the ability to modify permissions and roles.

### Key Changes:

1. **Permissions Manager (`src/sections/role/permission.jsx`)**
   - Removed the "Select All" functionality for both API and Client permissions
   - Disabled all permission switches
   - Removed unsaved changes alert
   - Removed state management for selection tracking

2. **Role Create Form (`src/sections/role/role-create-form.jsx`)**
   - Changed dialog title from "Create/Edit Role" to "View Role"
   - Removed create/update button
   - Changed "Cancel" button to "Close"
   - Removed LoadingButton component

3. **Role Table Toolbar (`src/sections/role/role-table-toolbar.jsx`)**
   - Removed "Add New Role" button
   - Simplified toolbar to only include search functionality

4. **User Dialog (`src/sections/user/view/user-dialog.jsx`)**
   - Added debug logging for user and currentUser objects

## Purpose
This update transforms the permissions management interface into a read-only view, removing the ability to modify permissions and roles. This change appears to be implementing a more restrictive access model where users can view but not modify permissions.

## Related
https://github.com/foyzulkarim/commitstreams-server/pull/19